### PR TITLE
feat: use security-severity property to determine priority

### DIFF
--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -198,6 +198,28 @@ public final class VulnerabilitiesProducer {
 				return Priority.valueOf(priorityString);
 			}
 		}
+		String securitySeverityString = getStringProperty(getRuleProperties(runData, result), "security-severity", null);
+		if ( StringUtils.isNotBlank(securitySeverityString) ) {
+			try {
+				float securitySeverity = Float.parseFloat(securitySeverityString);
+				// CVSS score range mapping from https://nvd.nist.gov/vuln-metrics/cvss
+				if ( securitySeverity < 0 ){
+					LOG.warn("Invalid security-severity, {} is less than 0.", securitySeverity);
+				}else if ( securitySeverity < 4 ){
+					return Priority.Low;
+				}else if ( securitySeverity < 7 ){
+					return Priority.Medium;
+				}else if ( securitySeverity < 9 ){
+					return Priority.High;
+				}else if ( securitySeverity <= 10 ){
+					return Priority.Critical;
+				}else{
+					LOG.warn("Invalid security-severity, {} is greater than 10.", securitySeverity);
+				}
+			} catch (NumberFormatException nfe) {
+				LOG.warn("Error converting {} string '{}' to float: {}", "security-severity", securitySeverityString, nfe.getMessage());
+			}
+		}
 		return result.resolveLevel(runData).getFortifyPriority();
 	}
 	

--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -192,13 +192,13 @@ public final class VulnerabilitiesProducer {
 	}
 
 	private Priority getPriority(RunData runData, Result result) {
-		String priorityString = null;
 		if ( isConvertedFromFortifyXml(runData) ) {
-			priorityString = getStringProperty(result.getProperties(), "priority", null);
+			String priorityString = getStringProperty(result.getProperties(), "priority", null);
+			if ( StringUtils.isNotBlank(priorityString) ) {
+				return Priority.valueOf(priorityString);
+			}
 		}
-		return StringUtils.isNotBlank(priorityString) 
-				? Priority.valueOf(priorityString)
-				: result.resolveLevel(runData).getFortifyPriority();
+		return result.resolveLevel(runData).getFortifyPriority();
 	}
 	
 	private String getRuleGuid(RunData runData, Result result) {


### PR DESCRIPTION
The security-severity property is a quasi-standard property that holds the CVSS score.

Tools such as Trivy include this property in SARIF they generate.

Tools such as GitHub consume this property, see:
https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#reportingdescriptor-object