### PR TITLE
feat: use location.message if available as the file name; use shortDescription if available as the category

### DIFF
--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/Location.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/Location.java
@@ -32,8 +32,8 @@ import lombok.Getter;
 public final class Location {
 	@JsonProperty private int id = -1;
 	@JsonProperty PhysicalLocation physicalLocation;
+	@JsonProperty Message message;
 	//@JsonProperty LogicalLocation[] logicalLocations;
-	//@JsonProperty Message message;
 	//@JsonProperty Region[] regions;
 	//@JsonProperty LocationRelationship[] relationships;
 }

--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/Result.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/Result.java
@@ -70,8 +70,12 @@ public final class Result {
 	public String resolveFullFileName(RunData runData, final String defaultValue) {
 		String value = defaultValue;
 		Location[] locations = getLocations();
-		if ( locations!=null && locations.length>0 && locations[0].getPhysicalLocation()!=null ) {
-			value = locations[0].getPhysicalLocation().resolveArtifactLocation(runData).getFullFileName(runData);
+		if ( locations!=null && locations.length>0 ) {
+			if ( locations[0].getMessage()!=null ){
+				value = resolveMessage(locations[0].getMessage(), runData);
+			} else if ( locations[0].getPhysicalLocation()!=null ) {
+				value = locations[0].getPhysicalLocation().resolveArtifactLocation(runData).getFullFileName(runData);
+			}
 		} else if ( getAnalysisTarget()!=null ) {
 			value = getAnalysisTarget().getFullFileName(runData);
 		}
@@ -160,9 +164,12 @@ public final class Result {
 		}
 		return level;
 	}
-	
+
 	public String getResultMessage(RunData runData) {
-		Message msg = getMessage();
+		return resolveMessage(getMessage(), runData);
+	}
+
+	protected String resolveMessage(Message msg, RunData runData) {
 		String text = msg.getText();
 		if ( StringUtils.isBlank(text) && msg.getId()!=null ) {
 			MultiformatMessageString msgString = getMultiformatMessageStringForId(runData, msg.getId());

--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/Result.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/Result.java
@@ -169,7 +169,7 @@ public final class Result {
 		return resolveMessage(getMessage(), runData);
 	}
 
-	protected String resolveMessage(Message msg, RunData runData) {
+	public String resolveMessage(Message msg, RunData runData) {
 		String text = msg.getText();
 		if ( StringUtils.isBlank(text) && msg.getId()!=null ) {
 			MultiformatMessageString msgString = getMultiformatMessageStringForId(runData, msg.getId());

--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -144,11 +144,16 @@ public final class VulnerabilitiesProducer {
 	private String getCategory(RunData runData, Result result) {
 		String category = null;
 		ReportingDescriptor rule = result.resolveRule(runData);
-		if ( rule != null && StringUtils.isNotBlank(rule.getName()) ) {
-			category = StringUtils.capitalize(StringUtils.join(StringUtils.splitByCharacterTypeCamelCase(rule.getName()), StringUtils.SPACE));
-		}
-		if ( StringUtils.isBlank(category) ) {
-			category = getStringProperty(getRuleProperties(rule), "Type", null);
+		if ( rule != null ) {
+			if ( rule.getShortDescription() != null ) {
+				category = result.resolveMessage(rule.getShortDescription(), runData);
+			}
+			if ( StringUtils.isBlank(category) && StringUtils.isNotBlank(rule.getName()) ) {
+				category = StringUtils.capitalize(StringUtils.join(StringUtils.splitByCharacterTypeCamelCase(rule.getName()), StringUtils.SPACE));
+			}
+			if ( StringUtils.isBlank(category) ) {
+				category = getStringProperty(getRuleProperties(rule), "Type", null);
+			}
 		}
 		if ( StringUtils.isBlank(category) ) {
 			category = result.resolveRuleId(runData);


### PR DESCRIPTION
Having "Primary Location" display the same value for every row (such as `/package.json` or `/pom.xml`) is not very user friendly.

SARIF allows a "message" to be provided for a location and that can have more useful information. See:
https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317675

The result is that instead of showing many rows with "Primary Location" of "/pom.xml", now each row has a different value such as "Package: org.postgresql:postgresql@42.3.6" and "package: org.yaml:snakeyaml@1.30"

Signed-off-by: Craig Andrews <candrews@integralblue.com>