### PR TITLE
feat: display help if available

### DIFF
--- a/src/main/java/com/fortify/ssc/parser/sarif/CustomVulnAttribute.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/CustomVulnAttribute.java
@@ -37,6 +37,7 @@ public enum CustomVulnAttribute implements com.fortify.plugin.spi.VulnerabilityA
 
 	toolName(AttrType.STRING), 
 	categoryAndSubCategory(AttrType.STRING),
+	help(AttrType.LONG_STRING),
     ;
 
     private final AttrType attributeType;

--- a/src/main/java/com/fortify/ssc/parser/sarif/CustomVulnAttribute.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/CustomVulnAttribute.java
@@ -38,6 +38,7 @@ public enum CustomVulnAttribute implements com.fortify.plugin.spi.VulnerabilityA
 	toolName(AttrType.STRING), 
 	categoryAndSubCategory(AttrType.STRING),
 	help(AttrType.LONG_STRING),
+	helpUri(AttrType.STRING),
     ;
 
     private final AttrType attributeType;

--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -103,7 +103,7 @@ public final class VulnerabilitiesProducer {
 		if ( rule != null && rule.getHelp() != null ) {
 			help = rule.getHelp().getText();
 		}
-		return help;
+		return StringUtils.isBlank(help) ? "Not Available" : help;
 	}
 
 	private String getHelpUri(RunData runData, Result result) {
@@ -112,7 +112,7 @@ public final class VulnerabilitiesProducer {
 		if ( rule != null && rule.getHelpUri() != null ) {
 			helpUri = rule.getHelpUri().toString();
 		}
-		return helpUri;
+		return StringUtils.isBlank(helpUri) ? "Not Available" : helpUri;
 	}
 
 	private String getFileName(RunData runData, Result result) {

--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -86,6 +86,7 @@ public final class VulnerabilitiesProducer {
 			
 			vb.setStringCustomAttributeValue(CustomVulnAttribute.categoryAndSubCategory, getCategoryAndSubCategory(runData, result));
 			vb.setStringCustomAttributeValue(CustomVulnAttribute.toolName, runData.getToolName());
+			vb.setStringCustomAttributeValue(CustomVulnAttribute.help, getHelp(runData, result));
     		
     		vb.completeVulnerability();
 		}
@@ -93,6 +94,15 @@ public final class VulnerabilitiesProducer {
 
 	private String getVulnerabilityAbstract(RunData runData, Result result) {
 		return result.getResultMessage(runData);
+	}
+
+	private String getHelp(RunData runData, Result result) {
+		String help = null;
+		ReportingDescriptor rule = result.resolveRule(runData);
+		if ( rule != null && rule.getHelp() != null ) {
+			help = rule.getHelp().getText();
+		}
+		return help;
 	}
 
 	private String getFileName(RunData runData, Result result) {

--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -87,6 +87,7 @@ public final class VulnerabilitiesProducer {
 			vb.setStringCustomAttributeValue(CustomVulnAttribute.categoryAndSubCategory, getCategoryAndSubCategory(runData, result));
 			vb.setStringCustomAttributeValue(CustomVulnAttribute.toolName, runData.getToolName());
 			vb.setStringCustomAttributeValue(CustomVulnAttribute.help, getHelp(runData, result));
+			vb.setStringCustomAttributeValue(CustomVulnAttribute.helpUri, getHelpUri(runData, result));
     		
     		vb.completeVulnerability();
 		}
@@ -103,6 +104,15 @@ public final class VulnerabilitiesProducer {
 			help = rule.getHelp().getText();
 		}
 		return help;
+	}
+
+	private String getHelpUri(RunData runData, Result result) {
+		String helpUri = null;
+		ReportingDescriptor rule = result.resolveRule(runData);
+		if ( rule != null && rule.getHelpUri() != null ) {
+			helpUri = rule.getHelpUri().toString();
+		}
+		return helpUri;
 	}
 
 	private String getFileName(RunData runData, Result result) {

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -5,7 +5,7 @@
     <plugin-info>
         <name>SARIF parser plugin</name>
         <version><!--VERSION-->0.0<!--/VERSION--></version>
-        <data-version>1</data-version>
+        <data-version>2</data-version>
         <vendor name="Micro Focus" url="https://www.microfocus.com"/>
         <description>SARIF parser plugin</description>
         <resources>

--- a/src/main/resources/resources/sarif_en.properties
+++ b/src/main/resources/resources/sarif_en.properties
@@ -20,5 +20,6 @@ confidence=Confidence
 friority=Criticality
 audited=Audited
 description=Description
+help=Help
 comment=Comment
 textBase64=Long text (base64 example)

--- a/src/main/resources/resources/sarif_en.properties
+++ b/src/main/resources/resources/sarif_en.properties
@@ -21,5 +21,6 @@ friority=Criticality
 audited=Audited
 description=Description
 help=Help
+helpUri=More Info
 comment=Comment
 textBase64=Long text (base64 example)

--- a/src/main/resources/viewtemplate/ViewTemplate.json
+++ b/src/main/resources/viewtemplate/ViewTemplate.json
@@ -44,5 +44,14 @@
 			"templateId": "COLLAPSE",
 			"dataType": "string"
 		}
+	],
+	[
+		{
+			"type": "template",
+			"title": "Help",
+			"key": "customAttributes.help",
+			"templateId": "COLLAPSE",
+			"dataType": "string"
+		}
 	]
 ]

--- a/src/main/resources/viewtemplate/ViewTemplate.json
+++ b/src/main/resources/viewtemplate/ViewTemplate.json
@@ -48,10 +48,23 @@
 	[
 		{
 			"type": "template",
-			"title": "Help",
-			"key": "customAttributes.help",
-			"templateId": "COLLAPSE",
-			"dataType": "string"
+			"title": "Additional Information",
+			"templateId": "TITLEBOX",
+			"dataType": "string",
+			"items": [
+				{
+					"type": "template",
+					"key": "customAttributes.help",
+					"templateId": "COLLAPSE",
+					"dataType": "string"
+				},
+				{
+					"type": "template",
+					"key": "customAttributes.helpUri",
+					"templateId": "SIMPLE",
+					"dataType": "string"
+				}
+			]
 		}
 	]
 ]


### PR DESCRIPTION
From the SARIF specification regarding help:
> A reportingDescriptor object MAY contain a property named help whose value is a localizable multiformatMessageString object (§3.12, §3.12.2) which provides the primary documentation for the reporting item.

https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317849

By making this information available in the Fortify SSC interface, the user is saved from having to browser to another site.

----

From the SARIF specification regarding help uri:
> A reportingDescriptor object MAY contain a property named helpUri whose value is a localizable string (§3.5.1) containing the absolute URI [RFC3986] of the primary documentation for the reporting item.

See: https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317848

By making this information available in the Fortify SSC interface, the user is saved from having to search for the identifier and instead they are directly linked to the source.
